### PR TITLE
Change NAP for Germany

### DIFF
--- a/content/api/other-apis/public-transport-europe.md
+++ b/content/api/other-apis/public-transport-europe.md
@@ -19,7 +19,7 @@ If you're interested in data outside of sweden, this list will help you get on t
 |🇪🇪 Estonia | http://www.peatus.ee/|
 |🇫🇮 Finland | http://www.finap.fi/ |
 |🇫🇷 France | https://transport.data.gouv.fr/ |
-|🇩🇪 Germany | https://service.mdm-portal.de/ |
+|🇩🇪 Germany | https://mobilithek.info/ |
 |🇬🇷 Greece | http://www.nap.gov.gr/ |
 |🇭🇺 Hungary | https://napportal.kozut.hu/ |
 |🇮🇪 Ireland | https://data.gov.ie/ |


### PR DESCRIPTION
MDM is deprecated, mobilithek.info is the replacement