### PR TITLE
Fix broken link

### DIFF
--- a/content/api/trafiklab-apis/resrobot-v21/timetables.md
+++ b/content/api/trafiklab-apis/resrobot-v21/timetables.md
@@ -48,7 +48,7 @@ details? These can be found in [the OpenAPI specification](api-spec.md).
 ## Example call
 
 This call will show all departures from Göteborg Central Station (740000002). The id can be obtained
-from [ResRobot Stop lookup](stop-lookup.md) or [GTFS Sverige 2](../../gtfs-datasets/gtfs-sverige-2/).
+from [ResRobot Stop lookup](stop-lookup.md) or [GTFS Sverige 2](/api/gtfs-datasets/gtfs-sverige-2/).
 
 ### Call
 


### PR DESCRIPTION
The relative link to GTFS Sverige 2 is broken, it has to go one more level up the directory tree. Replaced it with an absolute link to avoid future breakage if this file is moved.