### PR TITLE
Fix of Issue 43 - Required property should be "importance_level" and not "level"

### DIFF
--- a/static/openapi/sl-transport.json
+++ b/static/openapi/sl-transport.json
@@ -1260,7 +1260,7 @@
         },
         "required": [
           "id",
-          "level",
+          "importance_level",
           "message",
           "scope"
         ],


### PR DESCRIPTION
Fixes issues #43 where a required property has an incorrect name. This bug was introduced in [Commit 91724c6](https://github.com/trafiklab/trafiklab.se/commit/91724c611a7eda5a92e7f923e40e20b70d569de4#:~:text=Commit-,91724c6) when property was renamed.